### PR TITLE
某些情况下，上传图片会失败或者只上传了半张图片

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,17 +71,19 @@ var respond = function(static_url, callback) {
           var tmpdir = path.join(os.tmpDir(), path.basename(filename));
           var name = snowflake.nextId() + path.extname(tmpdir);
           var dest = path.join(static_url, img_url, name);
-
-          file.pipe(fs.createWriteStream(tmpdir));
-          fse.move(tmpdir, dest, function(err) {
-            if (err) throw err;
-            res.json({
-              'url': path.join(img_url, name),
-              'title': req.body.pictitle,
-              'original': filename,
-              'state': 'SUCCESS'
+          var writeStream = fs.createWriteStream(tmpdir);
+          writeStream.on("close", function () {
+            fse.move(tmpdir, dest, function(err) {
+              if (err) throw err;
+              res.json({
+                'url': path.join(img_url, name),
+                'title': req.body.pictitle,
+                'original': filename,
+                'state': 'SUCCESS'
+              });
             });
           });
+          file.pipe(writeStream);
         };
         callback(req, res, next);
       });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "tarball": "http://registry.npmjs.org/ueditor/-/ueditor-1.0.0.tgz"
   },
   "directories": {},
-  "_resolved": "https://registry.npmjs.org/ueditor/-/ueditor-1.0.0.tgz",
- 
+  "_resolved": "https://registry.npmjs.org/ueditor/-/ueditor-1.0.0.tgz"
+
 }


### PR DESCRIPTION
某些情况下，stream的pipe貌似还是异步IO的（虽然官方文档也没有提及这点），因此，在上传的图片还没有完全写入本地文件时，直接`fse.move`会发生error。

我的修复方法是`move`放到了`close`事件中，实际项目使用中，再没有出现过上传上传失败或者只上传了半张图片的情况。

